### PR TITLE
fix: 캘린더글자투명 날씨차트깨짐

### DIFF
--- a/src/pages/Weather/chart.jsx
+++ b/src/pages/Weather/chart.jsx
@@ -51,13 +51,13 @@ const DonutChart = ({ status, text }) => {
 
   return (
     <div>
-      <div style={{ position: 'relative', width: '10vw', height: '11vh' }}>
+      <div style={{ position: 'relative', width: '13vw', height: '13vw' }}>
         <Doughnut data={data} options={options} ref={chartRef} />
         <div
           style={{
             position: 'absolute',
-            top: '5vh',
-            left: '5vw',
+            top: '50%',
+            left: '50%',
             transform: 'translate(-50%, -50%)',
             textAlign: 'center',
           }}

--- a/src/styles/frame.css
+++ b/src/styles/frame.css
@@ -9,7 +9,7 @@
   font-weight: 400;
   line-height: 1.4;
   font-family: "Roboto", sans-serif;
-  color: #ffffff;
+  color: #000;
   width: 100%;
   font-family: "Noto Sans KR", sans-serif;
 }


### PR DESCRIPTION
캘린더 글자색이 하얀색으로 바뀌어서 날짜가 안보여서 검은색으로 다시 수정했습니다.
날씨 미세먼지 차트부분 깨져서 보이던거 다시 잘보이게 수정했습니다.
![666](https://github.com/Webpstudy/2023-1-WebProgramming-TGI/assets/19799955/0474e07b-61a3-4c90-aa5a-31f364c5fd7c)

![0999](https://github.com/Webpstudy/2023-1-WebProgramming-TGI/assets/19799955/6af372af-1a7f-4dee-b7c1-4822d2e8e568)

![555555](https://github.com/Webpstudy/2023-1-WebProgramming-TGI/assets/19799955/b90e0ac8-7086-4b98-9734-5748d15fb686)

![000011](https://github.com/Webpstudy/2023-1-WebProgramming-TGI/assets/19799955/9ca3606e-4730-4abf-ae8a-f1c05f0f4a0f)

